### PR TITLE
Added setHome function to set settings like homePresence to Home or Away

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Currently these methods are supported:
 - authorize();
 - me($token);
 - getHome($token,$home_id);
-- setHome($accessToken, $homeid, $settings);
+- setHome($access_token, $home_id, $settings);
 - getHomeWeather($token,$home_id);
 - getHomeDevices($token,$home_id);
 - getHomeInstallations($token,$home_id);

--- a/src/Restado.php
+++ b/src/Restado.php
@@ -78,12 +78,12 @@ class Restado {
     }
 
     /**
-     * @param $accessToken
-     * @param $homeid
+     * @param $access_token
+     * @param $home_id
      * @param $settings
      * @return mixed
      */
-    public function setHome($accessToken, $homeid, $settings) {
+    public function setHome($access_token, $home_id, $settings) {
         $provider = $this->getProvider();
 
         $options['body'] = json_encode($settings);
@@ -91,8 +91,8 @@ class Restado {
 
         $request = $provider->getAuthenticatedRequest(
             'PUT',
-            'https://my.tado.com/api/v2/homes/' . $homeid,
-            $accessToken,
+            'https://my.tado.com/api/v2/homes/' . $home_id,
+            $access_token,
             $options
         );
         $client = new \GuzzleHttp\Client();


### PR DESCRIPTION
Added a setHome function to set settings like homePresence to Home or Away. There was a get available already, but no set. Was it intentional? If not, here is a small addition that seems to work for me.