### PR TITLE
Fixed issue where only the last user defined the anyoneAtHome output

### DIFF
--- a/src/Restado.php
+++ b/src/Restado.php
@@ -718,17 +718,24 @@ class Restado {
         $home_id = $this->getHomeId();
 
         $anyoneAtHome = false;
+        $homeCount = 0;
 
         $homeUsers = $this->getHomeUsers($access_token, $home_id);
         foreach($homeUsers as $homeUser) {
             foreach($homeUser->mobileDevices as $device) {
-                $anyoneAtHome = $device->location->atHome == 1;
+                if($device->location->atHome) {
+                    $homeCount++;
+                }
             }
         }
 
+        if ($homeCount > 0) {
+            $anyoneAtHome = true;
+        }
+
         return $anyoneAtHome;
-    }
-  
+        }
+
      /**
      * @param $access_token
      * @return mixed


### PR DESCRIPTION
My previous PR to detect if anyone is at home (https://github.com/robertogallea/restado/pull/6) only used the last output, instead of taking into account that multiple people could be at home and actually checking if anyone is at home.