### PR TITLE
Updated OAuth2 Authentification based on device_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PHP and Laravel library for managing Tado system
 [![Total Downloads](https://img.shields.io/packagist/dt/robertogallea/restado.svg?style=flat-square)](https://packagist.org/packages/robertogallea/restado)
 
 
-This package provides a simple interface towards the public Tado Thermostat System API. It wraps the web methods available for authenticating users and retrieve information from the local devices. 
+This package provides a simple interface towards the public Tado Thermostat System API. It wraps the web methods available for authenticating users and retrieve information from the local devices.
 
 The package is also integrated within Laravel.
 
@@ -20,74 +20,78 @@ Since the API is currently officially undocumented, if you are aware of methods 
  4. [Usage](#4-usage)
  5. [Supported Methods](#5-supported-methods)
  6. [Issues, Questions and Pull Requests](#6-issues-questions-and-pull-requests)
- 
+
  ## 1. Installation
- 
+
  1. Require the package using composer:
- 
+
      ```
      composer require robertogallea/restado
      ```
-     
+
 2. Add the service provider to the `providers` in `config/app.php`:
 
     > Laravel 5.5 uses Package Auto-Discovery, so doesn't require you to manually add the ServiceProvider
 
     ```php
     Robertogallea\Restado\RestadoServiceProvider::class,
-    ```     
-    
-3. Add the alias to the `aliases` in `config/app.php`:
-    
-    ```php
-    'Restado' => Robertogallea\Restado\Facades\Restado::class,    
     ```
-    
+
+3. Add the alias to the `aliases` in `config/app.php`:
+
+    ```php
+    'Restado' => Robertogallea\Restado\Facades\Restado::class,
+    ```
+
 4. Add the following variables to your .env file
     ```php
-    TADO_CLIENT_ID=<TADO_APP_ID>       // defaults to public-api-preview
-    TADO_SECRET=<TADO_APP_SECRET_KEY>  // defaults to 4HJGRffVR8xb3XdEUQpjgZ1VplJi6Xgw                                                      
-    TADO_USER=<TADO_USER>
-    TADO_PASS=<TADO_PASSWORD>
-    TADO_HOME_ID=<TADO_HOME_ID>
+    TADO_CLIENT_ID=<TADO_APP_ID>       // defaults to 1bb50063-6b0c-4d11-bd99-387f4a91cc46
     ```
-    
-    
+
+
 ## 2. Updating
 
 1. To update this package,  update the composer package:
 
     ```php
     composer update robertogallea/restado
-    ```    
-    
+    ```
+
 ## 3. Configuration
-    
+
 1. To use Restado, no further configuration is required. However, if you wish to tweak with config, publish the relative
  configuration file using the command
 
 ```php
 php artisan vendor:publish --provider="Robertogallea\Restado\RestadoServiceProvider" --tag=config
 ```
-    
-## 4. Usage    
-To use this package you should use the method of the Restado facade. 
 
-1. Obtain a valid token for your session:
+## 4. Usage
+To use this package you should use the method of the Restado facade.
+
+1. Get the verification Data according to RFC8628 (device_code):
 
     ```php
-    $access_token = Restado::authorize();
-    ``` 
-    
-2. Use a method to get the related information, for example:
-    
+    $verificationData = Restado::getVerificationUrl();
+    ```
+
+2. Call the verification_uri_complete URL from $verificationData with a browser any complete the verfication process.
+
+3. Obtain a valid token for your session with device_code given in $verificationData in Step 1:
+
+    ```php
+    $access_token = Restado::authorize(['device_code' => $verificationData['device_code']]);
+    ```
+
+4. Use a method to get the related information, for example:
+
     ```php
     $me = Restado::me($access_token);
-    ```     
-    
+    ```
+
 each method returns an object containing the data from the server. Currently the API is not officially documented, the only reference I found is at this page: http://blog.scphillips.com/posts/2017/01/the-tado-api-v2/
 
- 
+
 ## 5. Supported Methods
 Currently these methods are supported:
 

--- a/src/Restado.php
+++ b/src/Restado.php
@@ -939,12 +939,24 @@ class Restado {
      * @return GenericProvider
      */
     private function getProvider() {
+
+        if (config('tado.timeout') !== NULL) {
+          $timeout = config('tado.timeout');
+        } else {
+          // set a timeout based on PHP max_execution_time if not configured
+          // in case of an invalid max_execution_time (empty or FALSE) a default of 20s is being set
+          // in case of an valid max_execution_time the timeout is being set to 90% of this value with a maximum of 20s
+          $timeout = floor((int)ini_get('max_execution_time') * 0.9);
+          if (($timeout>20) or ($timeout<=0)) $timeout = 20;
+        }
+
         return new GenericProvider([
             'clientId'                => config('tado.clientId'),    // The client ID assigned to you by the provider
             'clientSecret'            => config('tado.clientSecret'),   // The client password assigned to you by the provider
             'urlAuthorize'            => 'https://auth.tado.com/oauth/authorize',
             'urlAccessToken'          => 'https://auth.tado.com/oauth/token',
             'urlResourceOwnerDetails' => null,
+            'timeout'                 => $timeout,
         ]);
     }
 }

--- a/src/config/tado.php
+++ b/src/config/tado.php
@@ -2,10 +2,6 @@
 
 return [
 
-    'username' => env('TADO_USER', 'username'),
-    'password' => env('TADO_PASS', '********'),
-
-    'clientId'      => env('TADO_CLIENT_ID','public-api-preview'),
-    'clientSecret'  => env('TADO_SECRET','4HJGRffVR8xb3XdEUQpjgZ1VplJi6Xgw'),
+    'clientId'      => env('TADO_CLIENT_ID','1bb50063-6b0c-4d11-bd99-387f4a91cc46'),
 
 ];


### PR DESCRIPTION
see https://support.tado.com/en/articles/8565472-how-do-i-authenticate-to-access-the-rest-api

Note: device_code authentification for OAuth2-Client is needed - a pull-request is created but not merged yet: https://github.com/thephpleague/oauth2-client/pull/1065

Note 2: I have started to integrate TadoX and do some refactoring - but not yet finished - see https://github.com/slemke76/restado/tree/refactoring